### PR TITLE
Fix configparser interpolation error

### DIFF
--- a/gpoParser/core/sysvol.py
+++ b/gpoParser/core/sysvol.py
@@ -182,7 +182,7 @@ def parse_gpttmpl(gpo_objects):
                 def optionxform(self, option):
                     return option
 
-            config = CaseSensitiveConfigParser(allow_no_value=True, strict=False)
+            config = CaseSensitiveConfigParser(allow_no_value=True, strict=False, interpolation=None)
             config.read_string(gpo.raw_gpttmpl)
             # groups information
             if "Group Membership" in config.sections():


### PR DESCRIPTION
It seems that if some special characters are found in a policy (for example `%`), the script stops as it faces an error due to [Configparser interpolation logic](https://docs.python.org/3/library/configparser.html#interpolation-of-values):

```py
Retrieving \domain.local\Policies\{ABCD1234-61AC-48FC-9A47-6BA65FFD14FD}\User/Preferences/Groups/Groups.xml
Retrieving \domain.local\Policies\{ABCD1234-61AC-48FC-9A47-6BA65FFD14FD}\User/Preferences/Registry/Registry.xml
Traceback (most recent call last):
  File "/home/darktortue/.local/bin/gpoParser", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/darktortue/.local/share/pipx/venvs/gpoparser/lib/python3.13/site-packages/gpoParser/__init__.py", line 66, in main
    parse_sysvol_content(gpo_objects)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/darktortue/.local/share/pipx/venvs/gpoparser/lib/python3.13/site-packages/gpoParser/core/sysvol.py", line 172, in parse_sysvol_content
    parse_gpttmpl(gpo_objects)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/darktortue/.local/share/pipx/venvs/gpoparser/lib/python3.13/site-packages/gpoParser/core/sysvol.py", line 217, in parse_gpttmpl
    for item in config.items("Registry Values"):
                ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/configparser.py", line 890, in items
    return [(option, value_getter(option)) for option in orig_keys]
                     ~~~~~~~~~~~~^^^^^^^^
  File "/usr/lib/python3.13/configparser.py", line 886, in <lambda>
    value_getter = lambda option: self._interpolation.before_get(self,
                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
        section, option, d[option], d)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/configparser.py", line 415, in before_get
    self._interpolate_some(parser, option, L, value, section, defaults, 1)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/configparser.py", line 462, in _interpolate_some
    raise InterpolationSyntaxError(
    ...<2 lines>...
        "found: %r" % (rest,))

configparser.InterpolationSyntaxError: '%' must be followed by '%' or '(', found: '%*<>&#\'{([-|`_\\^ @)]}!:/"'
```

_Interpolation_ needs to be disabled to prevent the error.
```py
config = CaseSensitiveConfigParser(allow_no_value=True, strict=False, interpolation=None)
```