### PR TITLE
Fix BOM handling in config parser

### DIFF
--- a/gpoParser/core/sysvol.py
+++ b/gpoParser/core/sysvol.py
@@ -183,7 +183,7 @@ def parse_gpttmpl(gpo_objects):
                     return option
 
             config = CaseSensitiveConfigParser(allow_no_value=True, strict=False, interpolation=None)
-            config.read_string(gpo.raw_gpttmpl)
+            config.read_string(gpo.raw_gpttmpl.lstrip('\ufeff'))
             # groups information
             if "Group Membership" in config.sections():
                 for item in config.items("Group Membership"):


### PR DESCRIPTION
Trim BOM from raw_gpttmpl before reading it into config.

When running `gpoParser local sysvol/ ldap/` I got 

```
Traceback (most recent call last):
  File "/home/alex/.local/bin/gpoParser", line 6, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/alex/.local/share/pipx/venvs/gpoparser/lib/python3.12/site-packages/gpoParser/__init__.py", line 66, in main
    parse_sysvol_content(gpo_objects)
  File "/home/alex/.local/share/pipx/venvs/gpoparser/lib/python3.12/site-packages/gpoParser/core/sysvol.py", line 172, in parse_sysvol_content
    parse_gpttmpl(gpo_objects)
  File "/home/alex/.local/share/pipx/venvs/gpoparser/lib/python3.12/site-packages/gpoParser/core/sysvol.py", line 186, in parse_gpttmpl
    config.read_string(gpo.raw_gpttmpl)
  File "/usr/lib/python3.12/configparser.py", line 710, in read_string
    self.read_file(sfile, source)
  File "/usr/lib/python3.12/configparser.py", line 705, in read_file
    self._read(f, source)
  File "/usr/lib/python3.12/configparser.py", line 1064, in _read
    raise MissingSectionHeaderError(fpname, lineno, line)
configparser.MissingSectionHeaderError: File contains no section headers.
file: '<string>', line: 1
'\ufeff[Unicode]\r\n'
``` 

I've fixed the MissingSectionHeaderError in gpoParser/core/sysvol.py.

The issue was caused by a Byte Order Mark (BOM) character \ufeff at the start of the GptTmpl.inf file (which is typical for UTF-8 with BOM or UTF-16 files). The configparser module expects the file to start immediately with [ for the section header, so it threw an error when it saw the \ufeff.

I resolved this by stripping the \ufeff character from the parsed strings before feeding them to configparser, and I also proactively applied the same fix to the strings passed into minidom.parseString() to avoid similar XML parsing issues.

