### PR TITLE
Normalize computer DN to uppercase to ensure consistent matching.

### DIFF
--- a/gpoParser/core/display.py
+++ b/gpoParser/core/display.py
@@ -295,7 +295,7 @@ def display_gpos_affecting_computer(args, ou_objects, gpo_objects, sid_cache, dn
     matched = []
     for ou_dn, computers in dn_cache.items():
         for computer_dn in computers:
-            if target_computer in computer_dn:
+            if target_computer in computer_dn.upper():
                 matched.append((computer_dn, ou_dn))
     if not matched:
         print(f"No computer matching '{args.computer}' found")


### PR DESCRIPTION
The display code currently doesn't handle a case where the computer DN is lower-case in LDAP when trying to filter. Users cannot choose casing either because the filter function converts the name to upper. This PR normalizes DNs from the cache to upper-case to ensure consistent matching with provided computer name or DN.